### PR TITLE
Fix vercel configuration and add repo gap analysis

### DIFF
--- a/docs/repo_gap_analysis.md
+++ b/docs/repo_gap_analysis.md
@@ -1,0 +1,13 @@
+# Repository Gap Analysis
+
+## Deployment configuration
+- `vercel.json` previously contained invalid JSON (missing comma before `root`) and used the unsupported `root` key. The configuration now conforms to Vercel's Vite defaults by specifying build/install commands, `dist` output, and removing the invalid field.
+
+## Operational gaps
+- **Environment variables**: MongoDB and OpenAI integrations rely on `MONGODB_URI`, `DB_NAME`, `OPENAI_API_KEY`, and `VITE_OPENAI_API_KEY`, but the repository does not provide `.env.example` guidance or runtime validation. Without proper environment configuration, data fetching and AI features will fail.
+- **Backend usage**: `src/translations/db/mongo.ts` and `src/translations/db/openai.ts` pull in server-only dependencies (`mongodb`, `openai`) from the client bundle. These modules should either be moved to serverless functions or guarded to avoid client-side execution errors during static deployment.
+- **Testing/quality gates**: No automated tests or linting scripts are present beyond Vite build, leaving regressions undetected. Adding unit tests and CI linting would improve reliability.
+
+## Documentation opportunities
+- Add setup instructions for required environment variables and any backend API endpoints.
+- Clarify the deployment model (static vs serverless functions) to guide Vercel configuration and secure secret handling.

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,4 @@
   "outputDirectory": "dist",
   "installCommand": "npm install",
   "framework": "vite"
-  "root": "src"
 }


### PR DESCRIPTION
## Summary
- fix the Vercel configuration JSON to remove the invalid `root` key and syntax error
- document deployment/configuration gaps and operational risks in a new gap analysis doc

## Testing
- npm run build (fails: npm not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933171bada8832fb8f4b9d51157d441)