### PR TITLE
Fix PatientDashboard layout markup

### DIFF
--- a/src/components/dashboards/PatientDashboard.tsx
+++ b/src/components/dashboards/PatientDashboard.tsx
@@ -129,8 +129,8 @@ export default function PatientDashboard({ userInfo, onLogout }: PatientDashboar
         </div>
       </header>
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="flex flex-col lg:flex-row gap-8">
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="flex flex-col lg:flex-row gap-8">
           {/* Modern Sidebar Navigation */}
           <div className="lg:w-64">
             <nav className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-6 border border-white/20">
@@ -532,6 +532,7 @@ export default function PatientDashboard({ userInfo, onLogout }: PatientDashboar
         onMenuSelect={setActiveSection}
         activeMenu={activeSection}
       />
+    </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the patient dashboard content area in a `<main>` element for proper structure
- keep the floating menu within the main layout container and ensure closing tags are nested correctly
- close the outer dashboard wrapper to maintain valid JSX

## Testing
- not run (node/npm unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693322f12d00832f97c084693649824d)